### PR TITLE
:sparkles: Display empty and blank lines during tests

### DIFF
--- a/lib/src/test_options/value_with_test_options.dart
+++ b/lib/src/test_options/value_with_test_options.dart
@@ -8,7 +8,7 @@ class ValueWithTestOptions extends Iterable<dynamic> {
   final TestOptions testOptions;
 
   String get description =>
-      '[ ${value.map((e) => e.toString().trim().isEmpty ? '\'$e\'' : e.toString()).join(', ')} ]';
+      '[ ${value.map((e) => e is String ? '\'$e\'' : e.toString()).join(', ')} ]';
 
   @override
   Iterator<dynamic> get iterator => value.iterator;

--- a/lib/src/test_options/value_with_test_options.dart
+++ b/lib/src/test_options/value_with_test_options.dart
@@ -7,11 +7,14 @@ class ValueWithTestOptions extends Iterable<dynamic> {
   final Iterable<dynamic> value;
   final TestOptions testOptions;
 
+  String get description =>
+      '[ ${value.map((e) => e.toString().trim().isEmpty ? '\'$e\'' : e.toString()).join(', ')} ]';
+
   @override
   Iterator<dynamic> get iterator => value.iterator;
 
   GroupTestOptions get toGroupOptions => GroupTestOptions(
-        description: '$value',
+        description: description,
         skip: testOptions.skip,
         onPlatform: testOptions.onPlatform,
         retry: testOptions.retry,

--- a/lib/src/util/test_value_helpers.dart
+++ b/lib/src/util/test_value_helpers.dart
@@ -8,7 +8,6 @@ void mapTests(
   dynamic Function(Iterable<dynamic>) body,
 ) {
   for (final ValueWithTestOptions value in values) {
-
     value.testOptions.test(value.description, () {
       validityCheck(value, length);
       return body(value.value);

--- a/lib/src/util/test_value_helpers.dart
+++ b/lib/src/util/test_value_helpers.dart
@@ -8,7 +8,8 @@ void mapTests(
   dynamic Function(Iterable<dynamic>) body,
 ) {
   for (final ValueWithTestOptions value in values) {
-    value.testOptions.test('$value', () {
+
+    value.testOptions.test(value.description, () {
       validityCheck(value, length);
       return body(value.value);
     });

--- a/test/test_options/test_options_ext_test.dart
+++ b/test/test_options/test_options_ext_test.dart
@@ -57,7 +57,7 @@ void main() {
     expect(
       result,
       TypeMatcher<GroupTestOptions>()
-          .having((e) => e.description, 'desciption', '[1, 2, 3]')
+          .having((e) => e.description, 'desciption', '[ 1, 2, 3 ]')
           .having((e) => e.retry, 'retry', 1)
           .having((e) => e.onPlatform, 'onPlatform', {'foo': 'bar'})
           .having((e) => e.tags, 'tags', 'taggy')

--- a/test/test_options/value_with_test_options_test.dart
+++ b/test/test_options/value_with_test_options_test.dart
@@ -6,7 +6,9 @@ void main() {
   final TestOptions testOptions = TestOptions();
 
   group('description tests', () {
-    test('ValueWithTestOptions with only String values are wrapped with \'quotes\'', () {
+    test(
+        'ValueWithTestOptions with only String values are wrapped with \'quotes\'',
+        () {
       final result = ValueWithTestOptions(
         ['a', 'b', '', '   '],
         testOptions,
@@ -15,15 +17,17 @@ void main() {
       expect(result, "[ 'a', 'b', '', '   ' ]");
     });
 
-    test('ValueWithTestOptions with mixed types only String values are wrapped with \'quotes\'', () {
+    test(
+        'ValueWithTestOptions with mixed types only String values are wrapped with \'quotes\'',
+        () {
       final result = ValueWithTestOptions(
         ['a', 'b', '', '   ', 1, 1.5, true, _ClassWithToString()],
         testOptions,
       ).description;
 
-      expect(result, "[ 'a', 'b', '', '   ', 1, 1.5, true, class with toString ]");
+      expect(
+          result, "[ 'a', 'b', '', '   ', 1, 1.5, true, class with toString ]");
     });
-
   });
 }
 

--- a/test/test_options/value_with_test_options_test.dart
+++ b/test/test_options/value_with_test_options_test.dart
@@ -1,0 +1,33 @@
+import 'package:parameterized_test/src/test_options/test_options.dart';
+import 'package:parameterized_test/src/test_options/value_with_test_options.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final TestOptions testOptions = TestOptions();
+
+  group('description tests', () {
+    test('ValueWithTestOptions with only String values are wrapped with \'quotes\'', () {
+      final result = ValueWithTestOptions(
+        ['a', 'b', '', '   '],
+        testOptions,
+      ).description;
+
+      expect(result, "[ 'a', 'b', '', '   ' ]");
+    });
+
+    test('ValueWithTestOptions with mixed types only String values are wrapped with \'quotes\'', () {
+      final result = ValueWithTestOptions(
+        ['a', 'b', '', '   ', 1, 1.5, true, _ClassWithToString()],
+        testOptions,
+      ).description;
+
+      expect(result, "[ 'a', 'b', '', '   ', 1, 1.5, true, class with toString ]");
+    });
+
+  });
+}
+
+class _ClassWithToString {
+  @override
+  String toString() => 'class with toString';
+}

--- a/test/util/test_value_helpers_test.dart
+++ b/test/util/test_value_helpers_test.dart
@@ -68,7 +68,7 @@ void main() {
         executed.add(true);
       });
 
-      expect(result, ['(1)', '(2)']);
+      expect(result, ['[ 1 ]', '[ 2 ]']);
       expect(executed, [true, true]);
     });
   });
@@ -133,7 +133,7 @@ void main() {
         executed.add(true);
       });
 
-      expect(result, ['(1, 2)', '(3, 4)']);
+      expect(result, ['[ 1, 2 ]', '[ 3, 4 ]']);
       expect(executed, [true, true]);
     });
   });


### PR DESCRIPTION
Improved descriptions when running tests. Previously values where printed as is. Now there is a check if the value is a empty or blank line. If so its wrapped in `''` to make it clear there is a empty value.

|Previous output|Current output|
|----------------|--------------|
|`(john, doe , , )`    |`[ john, doe ,'' ,'  ' ]`|