### PR TITLE
:construction_worker: remove commented duplicated check from github pipeline

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -7,9 +7,9 @@ name: Dart
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   build:
@@ -29,10 +29,6 @@ jobs:
 
       - name: Check code format
         run: dart format . -o none --set-exit-if-changed
-
-      # Uncomment this step to verify the use of 'dart format' on each commit.
-      # - name: Verify formatting
-      #   run: dart format --output=none --set-exit-if-changed .
 
       # Consider passing '--fatal-infos' for slightly stricter analysis.
       - name: Analyze project source


### PR DESCRIPTION
## Description
The current changes aim to remove the commented duplicated check from the CI pipeline. 
This piece of code can be safely removed taking into account that the very same check is already done on line 31.
